### PR TITLE
fix go.mod module path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module Triangula-CLI
+module github.com/RH12503/Triangula-CLI
 
 go 1.16
 

--- a/triangula/main.go
+++ b/triangula/main.go
@@ -1,10 +1,11 @@
 package main
 
 import (
-	"Triangula-CLI/utils"
-	"github.com/urfave/cli/v2"
 	"log"
 	"os"
+
+	"github.com/RH12503/Triangula-CLI/utils"
+	"github.com/urfave/cli/v2"
 )
 
 func main() {

--- a/utils/render.go
+++ b/utils/render.go
@@ -1,17 +1,18 @@
 package utils
 
 import (
-	"Triangula-CLI/export"
 	"encoding/json"
 	"fmt"
-	"github.com/RH12503/Triangula/normgeom"
 	"io/ioutil"
 	"log"
 	"strings"
+
+	"github.com/RH12503/Triangula-CLI/export"
+	"github.com/RH12503/Triangula/normgeom"
 )
 
 // decodePoints reads and decodes an JSON file containing the data of points.
-func decodePoints(inputFile string) (normgeom.NormPointGroup, error){
+func decodePoints(inputFile string) (normgeom.NormPointGroup, error) {
 	jsonPoints, err := ioutil.ReadFile(inputFile)
 	if err != nil {
 		fmt.Println("\u001b[31merror reading input file\u001B[0m")
@@ -44,7 +45,7 @@ func RenderPNG(inputFile, outputFile, imageFile, effect string, scale float64) {
 	}
 
 	fmt.Println("Generating PNG...\u001b[0m")
-	filename := outputFile+ ".png"
+	filename := outputFile + ".png"
 	switch e := strings.ToLower(effect); e {
 	case "none":
 		err = export.WritePNG(filename, points, img, scale)
@@ -63,7 +64,7 @@ func RenderPNG(inputFile, outputFile, imageFile, effect string, scale float64) {
 		return
 	}
 
-	fmt.Println("\u001b[32mSuccessfully generated PNG at " +filename+ "!\u001B[0m")
+	fmt.Println("\u001b[32mSuccessfully generated PNG at " + filename + "!\u001B[0m")
 }
 
 // RenderSVG renders a triangulation to a SVG.
@@ -90,5 +91,5 @@ func RenderSVG(inputFile, outputFile, imageFile string) {
 		fmt.Println("\u001b[31merror generating SVG\u001b[0m")
 		return
 	}
-	fmt.Println("\u001b[32mSuccessfully generated SVG at " +outputFile+ ".svg!\u001B[0m")
+	fmt.Println("\u001b[32mSuccessfully generated SVG at " + outputFile + ".svg!\u001B[0m")
 }


### PR DESCRIPTION
When attempting to follow the documentation to install the CLI, the following error occurs:
```sh
❯ go get github.com/RH12503/Triangula-CLI/triangula
go get: github.com/RH12503/Triangula-CLI@none updating to
        github.com/RH12503/Triangula-CLI@v0.0.0-20210418062806-7dc6270d6db4: parsing go.mod:
        module declares its path as: Triangula-CLI
                but was required as: github.com/RH12503/Triangula-CLI
```

I believe this is because the `go.mod` had just the module name, but not the whole path. This PR _should_ fix this issue.

Read more about this in the Go blog: https://blog.golang.org/using-go-modules


As a side note, was there a design decision in order to move the CLI part of Triangula to it's own repository? I think we might be able to hold it in the main repo under a `cmd/` directory, if that is wanted.